### PR TITLE
feat(crypto): add `DerivePrivateKey2()` to crypto API

### DIFF
--- a/PrivmxEndpointCsharp/Crypto/CryptoApi.cs
+++ b/PrivmxEndpointCsharp/Crypto/CryptoApi.cs
@@ -79,13 +79,29 @@ namespace PrivMX.Endpoint.Crypto
         /// <summary>
         /// Derives a private key from a password and salt.
         /// The returned key is private key of elliptic curve cryptography. PBKDF2 algorithm is used to derive the key.
+        /// This method is deprecated. Use <see cref="CryptoApi.DerivePrivateKey2()"/> instead.
         /// </summary>
         /// <param name="password">The password used to derive from.</param>
         /// <param name="salt">The random additional data used to derive.</param>
         /// <returns>Derived private key in WIF format.</returns>
+        [Obsolete("Use CryptoApi.DerivePrivateKey2() instead")]
         public string DerivePrivateKey(string password, string salt)
         {
             return executor.Execute<string>(ptr, (int)CryptoApiNative.Method.DerivePrivateKey, new List<object>{password, salt});
+        }
+
+        /// <summary>
+        /// Derives a private key from a password and salt.
+        /// The returned key is private key of elliptic curve cryptography. PBKDF2 algorithm is used to derive the key.
+        /// Compared to <see cref="CryptoApi.DerivePrivateKey()"/>, this version of the derive function has an increased number of rounds.
+        /// This makes using this function a safer choice, but it makes the derived key different than in the previous version.
+        /// </summary>
+        /// <param name="password">The password used to derive from.</param>
+        /// <param name="salt">The random additional data used to derive.</param>
+        /// <returns>Derived private key in WIF format.</returns>
+        public string DerivePrivateKey2(string password, string salt)
+        {
+            return executor.Execute<string>(ptr, (int)CryptoApiNative.Method.DerivePrivateKey2, new List<object>{password, salt});
         }
 
         /// <summary>

--- a/PrivmxEndpointCsharp/Crypto/ICryptoApi.cs
+++ b/PrivmxEndpointCsharp/Crypto/ICryptoApi.cs
@@ -9,6 +9,8 @@
 // limitations under the License.
 //
 
+using System;
+
 namespace PrivMX.Endpoint.Crypto
 {
     public interface ICryptoApi
@@ -16,7 +18,9 @@ namespace PrivMX.Endpoint.Crypto
         byte[] SignData(byte[] data, string privateKey);
         bool VerifySignature(byte[] data, byte[] signature, string publicKey);
         string GeneratePrivateKey(string randomSeed = null);
+        [Obsolete("Use ICryptoApi.DerivePrivateKey2() instead")]
         string DerivePrivateKey(string password, string salt);
+        string DerivePrivateKey2(string password, string salt);
         string DerivePublicKey(string privateKey);
         byte[] GenerateKeySymmetric();
         byte[] EncryptDataSymmetric(byte[] data, byte[] symmetricKey);

--- a/PrivmxEndpointCsharp/Crypto/Internal/CryptoApiNative.cs
+++ b/PrivmxEndpointCsharp/Crypto/Internal/CryptoApiNative.cs
@@ -23,12 +23,13 @@ namespace PrivMX.Endpoint.Crypto.Internal
             SignData = 1,
             GeneratePrivateKey = 2,
             DerivePrivateKey = 3,
-            DerivePublicKey = 4,
-            GenerateKeySymmetric = 5,
-            EncryptDataSymmetric = 6,
-            DecryptDataSymmetric = 7,
-            ConvertPEMKeytoWIFKey = 8,
-            VerifySignature = 9,
+            DerivePrivateKey2 = 4,
+            DerivePublicKey = 5,
+            GenerateKeySymmetric = 6,
+            EncryptDataSymmetric = 7,
+            DecryptDataSymmetric = 8,
+            ConvertPEMKeytoWIFKey = 9,
+            VerifySignature = 10,
         }
 
         [DllImport("libprivmxendpointinterface")]


### PR DESCRIPTION
Add `DerivePrivateKey2()` to `CryptoApi`.
Mark `DerivePrivateKey()` as deprecated.
Add and update docummentation comments.
Update internal `Method` enum according to C++.

Refs: #8