### PR TITLE
Implement extractKey helper and refactor StreamKey for C# marshaling

### DIFF
--- a/PrivMX.Endpoint/Stream/IWebRTC.cs
+++ b/PrivMX.Endpoint/Stream/IWebRTC.cs
@@ -25,7 +25,7 @@ namespace PrivMX.Endpoint.Stream
         void SetAnswerAndSetRemoteDescription(string streamRoomId, string sdp, string type);
         void UpdateSessionId(string streamRoomId, long sessionId, string connectionType);
         void Close(string streamRoomId);
-        void UpdateKeys(string streamRoomId, List<Key> keys);
+        void UpdateKeys(string streamRoomId, List<StreamKey> keys);
     }
 }
 
@@ -45,7 +45,7 @@ namespace PrivMX.Endpoint.Stream
         void SetAnswerAndSetRemoteDescription(string streamRoomId, string sdp, string type);
         void UpdateSessionId(string streamRoomId, long sessionId, string connectionType);
         void Close(string streamRoomId);
-        void UpdateKeys(string streamRoomId, List<Key> keys);
+        void UpdateKeys(string streamRoomId, List<StreamKey> keys);
     }
 }
 

--- a/PrivMX.Endpoint/Stream/Internal/WebRTCNativeBridge.cs
+++ b/PrivMX.Endpoint/Stream/Internal/WebRTCNativeBridge.cs
@@ -88,17 +88,21 @@ namespace PrivMX.Endpoint.Stream.Internal
             proxyMap.Remove(streamRoomId);
         }
 
-        private static List<Key> mapKeys([In] CKey[] keys, IntPtr keySize)
+        private static List<StreamKey> mapKeys(IntPtr keys, IntPtr keysSize)
         {
-            var result = new List<Key>();
-            foreach (var key in keys)
+            var result = new List<StreamKey>();
+            for (long i = 0; i < keysSize.ToInt64(); ++i)
             {
-                byte[] keyVal = new byte[key.keySize.ToInt32()];
-                Marshal.Copy(key.key, keyVal, 0, key.keySize.ToInt32());
-                var newKey = new Key() {
-                    KeyId = key.keyId,
-                    key = keyVal,
-                    Type = mapKeyType(key.type),
+                var index = new IntPtr(i);
+                privmx_endpoint_stream_extractKey(keys, index, out IntPtr keyId, out IntPtr key, out IntPtr keySize, out CKeyType type);
+                string keyIdStr = Marshal.PtrToStringUTF8(keyId);
+                int keySizeInt = keySize.ToInt32();
+                byte[] keyBuf = new byte[keySizeInt];
+                Marshal.Copy(key, keyBuf, 0, keySizeInt);
+                var newKey = new StreamKey() {
+                    KeyId = keyIdStr,
+                    Key = keyBuf,
+                    Type = mapKeyType(type),
                 };
                 result.Add(newKey);
             }
@@ -128,7 +132,10 @@ namespace PrivMX.Endpoint.Stream.Internal
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void CloseDelegate(IntPtr ctx, string streamRoomId);
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate void UpdateKeysDelegate(IntPtr ctx, string streamRoomId, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] CKey[] keys, IntPtr keysSize);
+        private delegate void UpdateKeysDelegate(IntPtr ctx, string streamRoomId, IntPtr keys, IntPtr keysSize);
+
+        [DllImport("libprivmxendpointstream")]
+        private static extern int privmx_endpoint_stream_extractKey(IntPtr keys, IntPtr index, out IntPtr keyId, out IntPtr keyBuf, out IntPtr keySize, out CKeyType type);
 
         [DllImport("libprivmxendpointstream")]
         private static extern int privmx_endpoint_stream_newProxyWebRTC(

--- a/PrivMX.Endpoint/Stream/Models/StreamApiLow/StreamKey.cs
+++ b/PrivMX.Endpoint/Stream/Models/StreamApiLow/StreamKey.cs
@@ -11,10 +11,10 @@
 
 namespace PrivMX.Endpoint.Stream.Models.StreamApiLow
 {
-    public class Key
+    public class StreamKey
     {
         public string KeyId { get; set; }
-        public byte[] key { get; set; }
+        public byte[] Key { get; set; }
         public KeyType Type { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds the `extractKey` helper function to the `Stream` module C interface to support interop scenarios like C# P/Invoke. 

Key changes:
* Added `extractKey` function to extract values from `StreamKey` objects.
* Renamed class `Key` to `StreamKey` to avoid naming conflicts within the namespace.
* Renamed property `key` to `Key` within the new `StreamKey` class for better clarity and consistency.

Closes #21